### PR TITLE
Fixed the URL for "connecting to comet using SSH"

### DIFF
--- a/connecting_to_hpc_systems/README.md
+++ b/connecting_to_hpc_systems/README.md
@@ -3,6 +3,9 @@ In these tutorials, you will use your SDSC or XSEDE account to log onto the and 
 
 ## Updated by: Mary Thomas,  04/15/2020
 
-* [Connecting to Comet using SSH](./https://github.com/sdsc-hpc-training/basic_skills/blob/master/connecting_to_hpc_systems/connect_to_comet_ssh.md)
+
+* [Connecting to Comet using SSH]
+
+[Connecting to Comet using SSH]: https://github.com/sdsc-hpc-training/basic_skills/blob/master/connecting_to_hpc_systems/connect_to_comet_ssh.md
 
 


### PR DESCRIPTION
Hi, it seems the earlier URL had a double link (https:// ... https:// ... ) and was thus invalid. I have fixed this now. Could you please confirm if it works? Thank you!